### PR TITLE
✨ 支持 server.servlet.context-path 自适应配置

### DIFF
--- a/src/main/java/com/software/dev/config/ContextPathAdvice.java
+++ b/src/main/java/com/software/dev/config/ContextPathAdvice.java
@@ -1,0 +1,19 @@
+package com.software.dev.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+/**
+ * 向所有视图模型注入当前 context-path（如 /efmp-job；未配置则为空串），
+ * 供模板（templates/index.html、login.html）在 JS 中拼出自适应接口路径。
+ * 注意：Thymeleaf 3.1 起 ${#request} 不再默认可用，故通过 Model 注入。
+ */
+@ControllerAdvice
+public class ContextPathAdvice {
+
+    @ModelAttribute("contextPath")
+    public String contextPath(HttpServletRequest request) {
+        return request.getContextPath();
+    }
+}

--- a/src/main/java/com/software/dev/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/software/dev/interceptor/AuthInterceptor.java
@@ -12,14 +12,20 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // 剥离 context-path（如 /efmp-job），使白名单判断不受 server.servlet.context-path 配置影响
+        String contextPath = request.getContextPath();
         String requestURI = request.getRequestURI();
-        
+        String path = (contextPath != null && !contextPath.isEmpty() && requestURI.startsWith(contextPath))
+                ? requestURI.substring(contextPath.length())
+                : requestURI;
+
         // 允许访问的路径
-        if (requestURI.startsWith("/demo/") || 
-            requestURI.equals("/api/auth/login") || 
-            requestURI.equals("/api/auth/check") ||
-            requestURI.equals("/login") ||
-            requestURI.equals("/")) {
+        if (path.startsWith("/demo/") ||
+            path.equals("/api/auth/login") ||
+            path.equals("/api/auth/check") ||
+            path.equals("/login") ||
+            path.isEmpty() ||
+            path.equals("/")) {
             return true;
         }
         

--- a/src/main/resources/static/vite.config.js
+++ b/src/main/resources/static/vite.config.js
@@ -39,7 +39,8 @@ export default defineConfig({
     cors: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        // 后端地址；若后端配置了 context-path（如 /efmp-job），可设 VITE_API_TARGET=http://localhost:8080/efmp-job
+        target: process.env.VITE_API_TARGET || 'http://localhost:8080',
         changeOrigin: true,
         secure: false
       }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,14 +1,25 @@
  <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>API Scheduler</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/themes.css" rel="stylesheet">
+    <link th:href="@{/css/themes.css}" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <script th:inline="javascript">
+        // context-path 自适应：由后端注入当前 context path（如 /efmp-job；未配置则为空串）
+        window.CONTEXT_PATH = /*[[${contextPath}]]*/ '';
+        // 为所有 /api/ 开头的 axios 请求自动补上 context path，使接口路径自适应 server.servlet.context-path
+        axios.interceptors.request.use(function (config) {
+            if (config.url && config.url.indexOf('/api/') === 0) {
+                config.url = window.CONTEXT_PATH + config.url;
+            }
+            return config;
+        });
+    </script>
 </head>
 <body>
     <div id="app" class="container-fluid">
@@ -1327,20 +1338,20 @@
                         if (response.data.authenticated) {
                             this.currentUser = response.data.username;
                         } else {
-                            window.location.href = '/login';
+                            window.location.href = window.CONTEXT_PATH + '/login';
                         }
                     } catch (error) {
                         console.error('Auth check failed:', error);
-                        window.location.href = '/login';
+                        window.location.href = window.CONTEXT_PATH + '/login';
                     }
                 },
                 async logout() {
                     try {
                         await axios.post('/api/auth/logout');
-                        window.location.href = '/login';
+                        window.location.href = window.CONTEXT_PATH + '/login';
                     } catch (error) {
                         console.error('Logout failed:', error);
-                        window.location.href = '/login';
+                        window.location.href = window.CONTEXT_PATH + '/login';
                     }
                 },
                 // 断言相关方法

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -120,6 +120,17 @@
 
     <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <script th:inline="javascript">
+        // context-path 自适应：由后端注入当前 context path（如 /efmp-job；未配置则为空串）
+        window.CONTEXT_PATH = /*[[${contextPath}]]*/ '';
+        // 为所有 /api/ 开头的 axios 请求自动补上 context path，使接口路径自适应 server.servlet.context-path
+        axios.interceptors.request.use(function (config) {
+            if (config.url && config.url.indexOf('/api/') === 0) {
+                config.url = window.CONTEXT_PATH + config.url;
+            }
+            return config;
+        });
+    </script>
     <script>
         const { createApp } = Vue;
 
@@ -144,7 +155,7 @@
                         
                         if (response.data.success) {
                             // 登录成功，跳转到主页
-                            window.location.href = '/';
+                            window.location.href = window.CONTEXT_PATH + '/';
                         } else {
                             this.errorMessage = response.data.message || '登录失败';
                         }
@@ -164,7 +175,7 @@
                 // 检查是否已经登录
                 axios.get('/api/auth/check').then(response => {
                     if (response.data.authenticated) {
-                        window.location.href = '/';
+                        window.location.href = window.CONTEXT_PATH + '/';
                     }
                 }).catch(() => {
                     // 忽略检查错误


### PR DESCRIPTION
- AuthInterceptor 剥离 context-path 后再做白名单判断，避免配置 context-path 后登录/首页等接口被 401 拦截
- 新增 ContextPathAdvice 通过 @ModelAttribute 注入 contextPath 到视图模型（Thymeleaf 3.1 起 #request 不再默认可用）
- templates/index.html、login.html 注入 window.CONTEXT_PATH，注册 axios 拦截器为 /api/ 请求自动补齐 context path，页面跳转与静态资源路径同步自适应
- vite dev proxy 支持通过 VITE_API_TARGET 指定带 context-path 的后端地址